### PR TITLE
Chore/eslint9 upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           npm pack
 
       - name: Upload npm package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nw-eslint-config-npm-package
           retention-days: "15"

--- a/configurations/es6.js
+++ b/configurations/es6.js
@@ -13,7 +13,7 @@ module.exports = {
     "no-const-assign": "error", // https://eslint.org/docs/rules/no-const-assign
     "no-dupe-class-members": "off", // https://eslint.org/docs/rules/no-dupe-class-members
     "no-duplicate-imports": "off", // https://eslint.org/docs/rules/no-duplicate-imports
-    "no-new-symbol": "error", // https://eslint.org/docs/rules/no-new-symbol
+    "no-new-native-nonconstructor": "error", // https://eslint.org/docs/latest/rules/no-new-native-nonconstructor
     "no-restricted-exports": "off", // https://eslint.org/docs/rules/no-restricted-exports
     "no-restricted-imports": "off", // https://eslint.org/docs/rules/no-restricted-imports
     "no-this-before-super": "error", // https://eslint.org/docs/rules/no-this-before-super

--- a/configurations/stylistic.js
+++ b/configurations/stylistic.js
@@ -106,7 +106,7 @@ module.exports = {
     "max-nested-callbacks": ["error", { max: 2 }], // https://eslint.org/docs/rules/max-nested-callbacks
     "max-params": ["error", { max: 4 }], // https://eslint.org/docs/rules/max-params
     "max-statements": ["error", { max: 25 }, { ignoreTopLevelFunctions: false }], // https://eslint.org/docs/rules/max-statements
-    "max-statements-per-line": ["error", { max: 1 }], // https://eslint.org/docs/rules/max-statements-per-line
+    "@stylistic/max-statements-per-line": ["error", { max: 1 }], // https://eslint.style/rules/max-statements-per-line
     "multiline-comment-style": "off", // https://eslint.org/docs/rules/multiline-comment-style
     "multiline-ternary": "off", // https://eslint.org/docs/rules/multiline-ternary
     "new-cap": [
@@ -134,7 +134,7 @@ module.exports = {
     "no-multiple-empty-lines": "off", // https://eslint.org/docs/rules/no-multiple-empty-lines
     "no-negated-condition": "error", // https://eslint.org/docs/rules/no-negated-condition
     "no-nested-ternary": "error", // https://eslint.org/docs/rules/no-nested-ternary
-    "no-new-object": "error", // https://eslint.org/docs/rules/no-new-object
+    "no-object-constructor": "error", // https://eslint.org/docs/latest/rules/no-object-constructor
     "no-plusplus": "off", // https://eslint.org/docs/rules/no-plusplus
     "no-restricted-syntax": "off", // https://eslint.org/docs/rules/no-restricted-syntax
     "no-spaced-func": "off", // https://eslint.org/docs/rules/no-spaced-func
@@ -254,10 +254,10 @@ module.exports = {
       },
     },
     {
-      "files": ["*.{spec,test}.{ts,tsx}"],
-      "rules": {
-        "max-nested-callbacks": ["error", { "max": 4 }],
-      }
-    }
+      files: ["*.{spec,test}.{ts,tsx}"],
+      rules: {
+        "max-nested-callbacks": ["error", { max: 4 }],
+      },
+    },
   ],
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+const { FlatCompat } = require("@eslint/eslintrc");
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+module.exports = [
+  ...compat.config({
+    extends: ["./index.js"],
+  }),
+  {
+    ignores: ["node_modules/**"],
+  },
+];

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
     "./configurations/stylistic",
     "./configurations/jsx-a11y",
   ],
-  plugins: [],
+  plugins: ["@stylistic"],
   rules: {},
   overrides: [
     /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nimbleways/eslint-config",
   "description": "Nimbleways's standardized ESLint configuration with bundled dependencies.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index.js",
   "homepage": "https://github.com/nimbleways/eslint-config",
   "repository": "https://github.com/nimbleways/eslint-config",
@@ -20,28 +20,29 @@
     "release": "np"
   },
   "dependencies": {
-    "@rushstack/eslint-patch": "1.3.2",
-    "@typescript-eslint/eslint-plugin": "6.2.1",
-    "@typescript-eslint/parser": "6.2.1",
-    "eslint-config-prettier": "9.0.0",
-    "eslint-plugin-jsx-a11y": "6.7.1",
-    "eslint-plugin-prettier": "5.0.0",
-    "eslint-plugin-simple-import-sort": "10.0.0"
+    "@stylistic/eslint-plugin": "5.5.0",
+    "@rushstack/eslint-patch": "1.15.0",
+    "@typescript-eslint/eslint-plugin": "8.46.4",
+    "@typescript-eslint/parser": "8.46.4",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-jsx-a11y": "6.10.2",
+    "eslint-plugin-prettier": "5.5.4",
+    "eslint-plugin-simple-import-sort": "12.1.1"
   },
   "peerDependencies": {
-    "eslint": ">=8.27.0",
-    "prettier": ">=2.5.1",
-    "typescript": ">=4.5.4"
+    "eslint": "^9.0.0",
+    "prettier": ">=3.0.0",
+    "typescript": ">=4.8.4 <6.0.0"
   },
   "devDependencies": {
-    "@types/eslint": "^8.44.2",
-    "eslint": "8.46.0",
-    "eslint-find-rules": "^4.1.0",
+    "@types/eslint": "^9.6.1",
+    "eslint": "^9.39.1",
+    "eslint-find-rules": "^5.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "np": "^8.0.4",
-    "prettier": "3.0.1",
-    "typescript": "5.1.6"
+    "prettier": "3.6.2",
+    "typescript": "5.9.3"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Upgrade the published ESLint config to the ESLint 9 ecosystem (latest @typescript-eslint, Prettier 3.6, eslint-find-rules@5, and new @stylistic/eslint-plugin) and raise peer requirements so downstream users install compatible versions automatically.